### PR TITLE
1 Core/Misc: Fix GitRevision::GetHostOSVersion compilation on arch linu…

### DIFF
--- a/src/common/GitRevision.cpp
+++ b/src/common/GitRevision.cpp
@@ -45,9 +45,13 @@ char const* GitRevision::GetCMakeVersion()
 
 char const* GitRevision::GetHostOSVersion()
 {
-    return
+    return ""
 #ifdef TRINITY_BUILD_HOST_DISTRO_NAME
-        TRINITY_BUILD_HOST_DISTRO_NAME " " TRINITY_BUILD_HOST_DISTRO_VERSION_ID "; "
+        TRINITY_BUILD_HOST_DISTRO_NAME
+#ifdef TRINITY_BUILD_HOST_DISTRO_VERSION_ID
+        " " TRINITY_BUILD_HOST_DISTRO_VERSION_ID
+#endif
+        "; "
 #endif
         TRINITY_BUILD_HOST_SYSTEM " " TRINITY_BUILD_HOST_SYSTEM_VERSION
     ;


### PR DESCRIPTION
…x, TRINITY_BUILD_HOST_DISTRO_VERSION_ID is not defined there

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  
-  
-  

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
