### PR TITLE
1 DB/WorldStates: Added worldstate to enable BfA mythic dungeons

### DIFF
--- a/sql/updates/world/master/2024_09_20_00_world.sql
+++ b/sql/updates/world/master/2024_09_20_00_world.sql
@@ -1,0 +1,4 @@
+-- 
+DELETE FROM `world_state` WHERE `ID`=16474;
+INSERT INTO `world_state` (`ID`, `DefaultValue`, `MapIDs`, `AreaIDs`, `ScriptName`, `Comment`) VALUES
+(16474, 1, NULL, NULL, '', 'Battle for Azeroth - Enable Mythic Dungeons');


### PR DESCRIPTION
<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  
-  
-  

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
