### PR TITLE
fix(transmog): left shoulder pad not changing — stray modifier resets

### DIFF
--- a/src/server/game/Handlers/TransmogrificationHandler.cpp
+++ b/src/server/game/Handlers/TransmogrificationHandler.cpp
@@ -291,7 +291,6 @@ void WorldSession::HandleTransmogrifyItems(WorldPackets::Transmogrification::Tra
 
             item->SetModifier(AppearanceModifierSlotBySpec[player->GetActiveTalentGroup()], 0);
             item->SetModifier(SecondaryAppearanceModifierSlotBySpec[player->GetActiveTalentGroup()], 0);
-            item->SetModifier(ITEM_MODIFIER_ENCHANT_ILLUSION_ALL_SPECS, 0);
         }
 
         item->SetState(ITEM_CHANGED, player);
@@ -323,7 +322,6 @@ void WorldSession::HandleTransmogrifyItems(WorldPackets::Transmogrification::Tra
                 item->SetModifier(ITEM_MODIFIER_ENCHANT_ILLUSION_SPEC_5, item->GetModifier(ITEM_MODIFIER_ENCHANT_ILLUSION_ALL_SPECS));
 
             item->SetModifier(IllusionModifierSlotBySpec[player->GetActiveTalentGroup()], 0);
-            item->SetModifier(ITEM_MODIFIER_TRANSMOG_APPEARANCE_ALL_SPECS, 0);
         }
 
         item->SetState(ITEM_CHANGED, player);


### PR DESCRIPTION
## The Problem

Left shoulder pad transmog doesn't change — no reaction when applying. This is because the `CurrentSpecOnly` paths in `HandleTransmogrifyItems` had stray `SetModifier` calls that wiped unrelated modifiers:

- **Resetting appearance** also zeroed `ENCHANT_ILLUSION_ALL_SPECS` (nuked weapon illusions)
- **Resetting illusion** also zeroed `TRANSMOG_APPEARANCE_ALL_SPECS` (nuked all-specs appearance, including secondary shoulder)

The secondary shoulder appearance depends on the primary appearance modifier chain being intact. When the illusion reset path wiped `TRANSMOG_APPEARANCE_ALL_SPECS`, it killed the secondary shoulder appearance as collateral damage.

## The Fix

Remove the two stray lines. Each reset path now only touches its own modifiers:
- Appearance reset: only touches appearance modifiers
- Illusion reset: only touches illusion modifiers

2 lines removed, 0 added.

This is probably the specific fix for the left shoulder issue you mentioned. If not, I have a larger set of transmog hardening fixes I can send over that covers more ground — just let me know.

## Test
- [x] Build passes
- [x] Left shoulder pad transmog changes correctly (video sent on Discord)